### PR TITLE
Wrapped Protocols Get Request Access

### DIFF
--- a/txsockjs/protocols/base.py
+++ b/txsockjs/protocols/base.py
@@ -56,10 +56,12 @@ class StubResource(resource.Resource, ProtocolWrapper):
         directlyProvides(self, providedBy(request.transport))
         protocol.Protocol.makeConnection(self, request.transport)
         self.session.makeConnection(self)
+        self.session.protocol.request = request
         request.notifyFinish().addErrback(self.connectionLost)
         return server.NOT_DONE_YET
     
     def disconnect(self):
+        self.session.protocol.request = None
         self.request.finish()
         self.session.transportLeft()
     

--- a/txsockjs/protocols/websocket.py
+++ b/txsockjs/protocols/websocket.py
@@ -102,8 +102,20 @@ class RawWebSocket(WebSocketsResource, OldWebSocketsResource):
             protocol = self._oldfactory.buildProtocol(request.transport.getPeer())
         else:
             protocol = self._factory.buildProtocol(request.transport.getPeer())
+        
         protocol.request = request
         protocol.parent = self.parent
+        
+        # give our wrapped protocols access to request too
+        proto = protocol
+        while True:
+            proto.request = request
+            proto.parent = self.parent
+            p = getattr(proto, 'wrappedProtocol', None)
+            if not p:
+                break
+            proto = p
+        
         return protocol, None
     
     def render(self, request):


### PR DESCRIPTION
Allow protocols produced by factories wrapped with SockJSResource toh ave access to the request object via protocol.request. Such that developers can use site sessions in order to validate a socket connection, ie. 'request.getSession()'. This allows for socket connections to be verified for a user without sending any communication over the socket that may help compromise the account security (perhaps).
