### PR TITLE
Fix injection of unicode

### DIFF
--- a/txsockjs/protocols/websocket.py
+++ b/txsockjs/protocols/websocket.py
@@ -75,7 +75,12 @@ class JsonProtocol(PeerOverrideProtocol):
         if not data:
             return
         try:
-            dat = json.loads(data)
+            unicodedat = json.loads(data)
+            dat = []
+            for item in unicodedat:
+                if isinstance(item, unicode):
+                    item = item.encode("utf-8")
+                dat.append(item)
         except ValueError:
             self.transport.loseConnection()
         else:


### PR DESCRIPTION
As previously discussed, this fixes the injection of unicode when we're already receiving strings in other places.  (If I turn off websockets in my browser, everything stops breaking.)

This fixes one of the two issues we encounter with txircd.
