### PR TITLE
Fix outgoing messages that aren't valid UTF-8 being sent unchanged

### DIFF
--- a/txsockjs/protocols/websocket.py
+++ b/txsockjs/protocols/websocket.py
@@ -60,8 +60,8 @@ class JsonProtocol(PeerOverrideProtocol):
         self.writeSequence([data])
     
     def writeSequence(self, data):
-        for p in data:
-            p = normalize(p, self.parent._options['encoding'])
+        for index, p in enumerate(data):
+            data[index] = normalize(p, self.parent._options['encoding'])
         self.transport.write("a{0}".format(json.dumps(data, separators=(',',':'))))
     
     def writeRaw(self, data):


### PR DESCRIPTION
This fixes the bug I couldn't work around in previous txircd versions where non-UTF-8 non-ASCII text would result in an exception being thrown and the message not being sent to most of the users.
