### PR TITLE
Fix error caused by attempting to modify a tuple

### DIFF
--- a/txsockjs/protocols/base.py
+++ b/txsockjs/protocols/base.py
@@ -148,6 +148,7 @@ class Stub(ProtocolWrapper):
         self.sendData()
     
     def writeSequence(self, data):
+        data = list(data)
         for index, p in enumerate(data):
             data[index] = normalize(p, self.parent._options['encoding'])
         self.buffer.extend(data)

--- a/txsockjs/protocols/websocket.py
+++ b/txsockjs/protocols/websocket.py
@@ -61,6 +61,7 @@ class JsonProtocol(PeerOverrideProtocol):
         self.writeSequence([data])
     
     def writeSequence(self, data):
+        data = list(data)
         for index, p in enumerate(data):
             data[index] = normalize(p, self.parent._options['encoding'])
         self.transport.write("a{0}".format(json.dumps(data, separators=(',',':'))))


### PR DESCRIPTION
Twisted calls this function with a tuple. Let me know if we need to figure out how to submit this upstream instead.

pdb traceback from txircd:

```
  /home/alchy/txircd/txircd/user.py(74)dataReceived()
-> IRCBase.dataReceived(self, data)
  /home/alchy/txircd/lib/python2.7/site-packages/twisted/protocols/basic.py(454)dataReceived()
-> self.lineReceived(line)
  /home/alchy/txircd/txircd/ircbase.py(10)lineReceived()
-> self.handleCommand(command, params, prefix, tags)
  /home/alchy/txircd/txircd/user.py(145)handleCommand()
-> if handler[0].execute(self, data):
  /home/alchy/txircd/txircd/modules/ircv3/cap.py(127)execute()
-> user.sendMessage("CAP", "LS", splitCapabilities[0]) # We can only send one line to 3.1 clients
  /home/alchy/txircd/txircd/user.py(106)sendMessage()
-> IRCBase.sendMessage(self, command, *args, **kw)
  /home/alchy/txircd/txircd/ircbase.py(115)sendMessage()
-> self.sendLine(lineToSend.replace("\0", ""))
  /home/alchy/txircd/txircd/user.py(82)sendLine()
-> IRCBase.sendLine(self, line)
  /home/alchy/txircd/lib/python2.7/site-packages/twisted/protocols/basic.py(476)sendLine()
-> return self.transport.writeSequence((line, self.delimiter))
> /home/alchy/txircd/lib/python2.7/site-packages/txsockjs/protocols/base.py(152)writeSequence()
-> data[index] = normalize(p, self.parent._options['encoding'])
```

It looks like `txsockjs.protocols.base.writeSequence` is called directly from `twisted.protocols.basic.LineOnlyReceiver`.
