### PR TITLE
Fix HTTP 502 issue when using pypy

### DIFF
--- a/txsockjs/protocols/websocket.py
+++ b/txsockjs/protocols/websocket.py
@@ -48,7 +48,7 @@ class PeerOverrideProtocol(ProtocolWrapper):
                 return address.IPv6Address("TCP", ip, None)
         return ProtocolWrapper.getPeer(self)
 
-class JsonProtocol(PeerOverrideProtocol):
+class JsonProtocol(PeerOverrideProtocol, object):
     def makeConnection(self, transport):
         directlyProvides(self, providedBy(transport))
         Protocol.makeConnection(self, transport)

--- a/txsockjs/websockets.py
+++ b/txsockjs/websockets.py
@@ -263,7 +263,7 @@ def _parseFrames(buf):
 
 
 
-class _WebSocketsProtocol(ProtocolWrapper):
+class _WebSocketsProtocol(ProtocolWrapper, object):
     """
     Protocol which wraps another protocol to provide a WebSockets transport
     layer.


### PR DESCRIPTION
While trying to switch from CPython to Pypy with my coworker we went into this issue: #18 
After many hours of struggle, we fixed it by inheriting from "object".
This fixes the strange behaviour of "self" being None in JSONProtocol and _webSocketsProtocol __init__.

It could be a good idea to spread this good practice to other classes as well.