### PR TITLE
Switch to the implements declaration style zope requires in python 3

### DIFF
--- a/twisted/plugins/sockjs_endpoints.py
+++ b/twisted/plugins/sockjs_endpoints.py
@@ -23,15 +23,14 @@
 # OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from zope.interface import implements
+from zope.interface import implementer
 from twisted.plugin import IPlugin
 from twisted.internet.interfaces import IStreamServerEndpointStringParser, IStreamServerEndpoint
 from twisted.internet.endpoints import serverFromString
 from txsockjs.factory import SockJSFactory
 
+@implementer(IPlugin, IStreamServerEndpointStringParser)
 class SockJSServerParser(object):
-	implements(IPlugin, IStreamServerEndpointStringParser)
-
 	prefix = "sockjs"
 
 	def parseStreamServer(self, reactor, description, **options):
@@ -53,9 +52,8 @@ class SockJSServerParser(object):
 		endpoint = serverFromString(reactor, description)
 		return SockJSServerEndpoint(endpoint, options)
 
+@implementer(IPlugin, IStreamServerEndpoint)
 class SockJSServerEndpoint(object):
-	implements(IPlugin, IStreamServerEndpoint)
-
 	def __init__(self, endpoint, options):
 		self._endpoint = endpoint
 		self._options = options


### PR DESCRIPTION
In Python 3, `zope.interface` requires using the `@implements` decorator rather than `implements` function calls. This should work in Python 2 & 3 (as opposed to the `implements()` call which is an error in Python 3).